### PR TITLE
Linux buildfixes

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -221,7 +221,7 @@ PROPERTIES
 )
 
 set(VISUAL_BOY_COMMON
-    LINK tt_base
+    LINK tt_base z
     PROPERTIES FOLDER 3rdParty
     DEFINES PRIVATE C_CORE NO_LINK NO_PNG register=
 )

--- a/src/engine/shared/inc/visualboy/lib/gba/gbafilter.h
+++ b/src/engine/shared/inc/visualboy/lib/gba/gbafilter.h
@@ -1,4 +1,4 @@
-#include "../System.h"
+#include <stdint.h>
 
 void gbafilter_pal(uint16_t* buf, int count);
 void gbafilter_pal32(uint32_t* buf, int count);

--- a/src/engine/shared/src/recastnavigation/Detour/DetourNavMeshBuilder.cpp
+++ b/src/engine/shared/src/recastnavigation/Detour/DetourNavMeshBuilder.cpp
@@ -37,7 +37,13 @@ struct BVItem
 	int i;
 };
 
-static int __cdecl compareItemX(const void* va, const void* vb)
+#ifdef _WIN32
+#define RECASTAPI __cdecl
+#else
+#define RECASTAPI
+#endif
+
+static int RECASTAPI compareItemX(const void* va, const void* vb)
 {
 	const BVItem* a = (const BVItem*)va;
 	const BVItem* b = (const BVItem*)vb;
@@ -48,7 +54,7 @@ static int __cdecl compareItemX(const void* va, const void* vb)
 	return 0;
 }
 
-static int __cdecl compareItemY(const void* va, const void* vb)
+static int RECASTAPI compareItemY(const void* va, const void* vb)
 {
 	const BVItem* a = (const BVItem*)va;
 	const BVItem* b = (const BVItem*)vb;
@@ -59,7 +65,7 @@ static int __cdecl compareItemY(const void* va, const void* vb)
 	return 0;
 }
 
-static int __cdecl compareItemZ(const void* va, const void* vb)
+static int RECASTAPI compareItemZ(const void* va, const void* vb)
 {
 	const BVItem* a = (const BVItem*)va;
 	const BVItem* b = (const BVItem*)vb;

--- a/src/engine/shared/src/tt/compression/png.cpp
+++ b/src/engine/shared/src/tt/compression/png.cpp
@@ -13,14 +13,14 @@ namespace compression {
 
 
 // PNG custom function declarations
-void      __cdecl pngReadData    (png_structp p_pngPtr, png_bytep p_targetData, png_size_t p_requestedLength);
-void      __cdecl pngWriteData   (png_structp p_pngPtr, png_bytep p_dataToWrite, png_size_t p_dataLength);
-png_voidp __cdecl pngMalloc      (png_structp p_pngPtr, png_size_t p_size);
-void      __cdecl pngFree        (png_structp p_pngPtr, png_voidp p_ptr);
-void      __cdecl pngReadError   (png_structp p_pngPtr, png_const_charp p_errorMessage);
-void      __cdecl pngReadWarning (png_structp p_pngPtr, png_const_charp p_errorMessage);
-void      __cdecl pngWriteError  (png_structp p_pngPtr, png_const_charp p_errorMessage);
-void      __cdecl pngWriteWarning(png_structp p_pngPtr, png_const_charp p_errorMessage);
+void      PNGCAPI pngReadData    (png_structp p_pngPtr, png_bytep p_targetData, png_size_t p_requestedLength);
+void      PNGCAPI pngWriteData   (png_structp p_pngPtr, png_bytep p_dataToWrite, png_size_t p_dataLength);
+png_voidp PNGCAPI pngMalloc      (png_structp p_pngPtr, png_size_t p_size);
+void      PNGCAPI pngFree        (png_structp p_pngPtr, png_voidp p_ptr);
+void      PNGCAPI pngReadError   (png_structp p_pngPtr, png_const_charp p_errorMessage);
+void      PNGCAPI pngReadWarning (png_structp p_pngPtr, png_const_charp p_errorMessage);
+void      PNGCAPI pngWriteError  (png_structp p_pngPtr, png_const_charp p_errorMessage);
+void      PNGCAPI pngWriteWarning(png_structp p_pngPtr, png_const_charp p_errorMessage);
 
 
 // PNG Header information
@@ -375,7 +375,7 @@ void modifySettingsForRGBA(png_structp p_png, const PNGHeader& p_header, const P
 //--------------------------------------------------------------------------------------------------
 // PNG Custom function implementations
 
-void __cdecl pngReadData(png_structp p_pngPtr, png_bytep p_targetData, png_size_t p_requestedLength)
+void PNGCAPI pngReadData(png_structp p_pngPtr, png_bytep p_targetData, png_size_t p_requestedLength)
 {
 	void* ioPtr = png_get_io_ptr(p_pngPtr);
 	if (ioPtr == 0)
@@ -399,7 +399,7 @@ void __cdecl pngReadData(png_structp p_pngPtr, png_bytep p_targetData, png_size_
 }
 
 
-void __cdecl pngWriteData(png_structp p_pngPtr, png_bytep p_dataToWrite, png_size_t p_dataLength)
+void PNGCAPI pngWriteData(png_structp p_pngPtr, png_bytep p_dataToWrite, png_size_t p_dataLength)
 {
 	void* ioPtr = png_get_io_ptr(p_pngPtr);
 	if (ioPtr == 0)
@@ -418,7 +418,7 @@ void __cdecl pngWriteData(png_structp p_pngPtr, png_bytep p_dataToWrite, png_siz
 }
 
 
-png_voidp __cdecl pngMalloc(png_structp p_pngPtr, png_size_t p_size)
+png_voidp PNGCAPI pngMalloc(png_structp p_pngPtr, png_size_t p_size)
 {
 	if (p_pngPtr == 0 || p_size == 0)
 	{
@@ -428,7 +428,7 @@ png_voidp __cdecl pngMalloc(png_structp p_pngPtr, png_size_t p_size)
 }
 
 
-void __cdecl pngFree(png_structp p_pngPtr, png_voidp p_ptr)
+void PNGCAPI pngFree(png_structp p_pngPtr, png_voidp p_ptr)
 {
 	if (p_pngPtr != 0 && p_ptr != 0)
 	{
@@ -437,7 +437,7 @@ void __cdecl pngFree(png_structp p_pngPtr, png_voidp p_ptr)
 }
 
 
-void __cdecl pngReadError(png_structp p_pngPtr, png_const_charp p_errorMessage)
+void PNGCAPI pngReadError(png_structp p_pngPtr, png_const_charp p_errorMessage)
 {
 #if !defined(TT_BUILD_FINAL)
 	const char* filename = "";
@@ -456,7 +456,7 @@ void __cdecl pngReadError(png_structp p_pngPtr, png_const_charp p_errorMessage)
 }
 
 
-void __cdecl pngReadWarning(png_structp p_pngPtr, png_const_charp p_errorMessage)
+void PNGCAPI pngReadWarning(png_structp p_pngPtr, png_const_charp p_errorMessage)
 {
 #if !defined(TT_BUILD_FINAL)
 	const char* filename = "";
@@ -475,7 +475,7 @@ void __cdecl pngReadWarning(png_structp p_pngPtr, png_const_charp p_errorMessage
 }
 
 
-void __cdecl pngWriteError(png_structp p_pngPtr, png_const_charp p_errorMessage)
+void PNGCAPI pngWriteError(png_structp p_pngPtr, png_const_charp p_errorMessage)
 {
 #if !defined(TT_BUILD_FINAL)
 	const char* filename = "";
@@ -494,7 +494,7 @@ void __cdecl pngWriteError(png_structp p_pngPtr, png_const_charp p_errorMessage)
 }
 
 
-void __cdecl pngWriteWarning(png_structp p_pngPtr, png_const_charp p_errorMessage)
+void PNGCAPI pngWriteWarning(png_structp p_pngPtr, png_const_charp p_errorMessage)
 {
 #if !defined(TT_BUILD_FINAL)
 	const char* filename = "";

--- a/src/engine/shared/src/vorbis/floor1.c
+++ b/src/engine/shared/src/vorbis/floor1.c
@@ -193,7 +193,12 @@ static vorbis_info_floor *floor1_unpack (vorbis_info *vi,oggpack_buffer *opb){
   return(NULL);
 }
 
-static int __cdecl icomp(const void *a,const void *b){
+#ifdef _WIN32
+#define VORBISAPI __cdecl
+#else
+#define VORBISAPI
+#endif
+static int VORBISAPI icomp(const void *a,const void *b){
   return(**(int **)a-**(int **)b);
 }
 

--- a/src/engine/shared/src/vorbis/lsp.c
+++ b/src/engine/shared/src/vorbis/lsp.c
@@ -294,7 +294,12 @@ static void cheby(float *g, int ord) {
   }
 }
 
-static int __cdecl comp(const void *a,const void *b){
+#ifdef _WIN32
+#define VORBISAPI __cdecl
+#else
+#define VORBISAPI
+#endif
+static int VORBISAPI comp(const void *a,const void *b){
   return (*(float *)a<*(float *)b)-(*(float *)a>*(float *)b);
 }
 

--- a/src/engine/shared/src/vorbis/psy.c
+++ b/src/engine/shared/src/vorbis/psy.c
@@ -1022,7 +1022,12 @@ float **_vp_quantize_couple_memo(vorbis_block *vb,
 }
 
 /* this is for per-channel noise normalization */
-static int __cdecl apsort(const void *a, const void *b){
+#ifdef _WIN32
+#define VORBISAPI __cdecl
+#else
+#define VORBISAPI
+#endif
+static int VORBISAPI apsort(const void *a, const void *b){
   float f1=(float)fabs(**(float**)a);
   float f2=(float)fabs(**(float**)b);
   return (f1<f2)-(f1>f2);

--- a/src/engine/shared/src/vorbis/sharedbook.c
+++ b/src/engine/shared/src/vorbis/sharedbook.c
@@ -313,7 +313,12 @@ static ogg_uint32_t bitreverse(ogg_uint32_t x){
   return((x>> 1)&0x55555555UL) | ((x<< 1)&0xaaaaaaaaUL);
 }
 
-static int __cdecl sort32a(const void *a,const void *b){
+#ifdef _WIN32
+#define VORBISAPI __cdecl
+#else
+#define VORBISAPI
+#endif
+static int VORBISAPI sort32a(const void *a,const void *b){
   return ( **(ogg_uint32_t **)a>**(ogg_uint32_t **)b)- 
     ( **(ogg_uint32_t **)a<**(ogg_uint32_t **)b);
 }


### PR DESCRIPTION
- A whole lot of __cdecl macros
- gbafilter.h only needs stdint
- VisualBoy depends on zlib

Fixes #1